### PR TITLE
Make serde support work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ The IEEE claims trademarks on the names EUI-48 and EUI-64, in which EUI is an ab
 
 [dependencies]
 rustc-serialize = "0.3"
-serde = { version = "0.6", optional = true }
+serde = { version = "~1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,23 @@ pub enum ParseError {
 }
 
 impl MacAddress {
-    /// Create a new MacAddress from vec![u8; 6]
+    /// Create a new MacAddress from `[u8; 6]`.
     pub fn new( eui: Eui48 ) -> MacAddress {
         MacAddress { eui: eui }
+    }
+
+    /// Create a new MacAddress from a byte slice.
+    ///
+    /// Returns an error (without any description) if the slice doesn't have the proper length.
+    pub fn from_bytes( bytes: &[u8] ) -> Result<Self, ()> {
+        if bytes.len() != EUI48LEN {
+            return Err(());
+        }
+        let mut input: [u8; EUI48LEN] = Default::default();
+        for i in 0..EUI48LEN {
+            input[i] = bytes[i];
+        }
+        Ok(Self::new(input))
     }
 
     /// Returns empty EUI-48 address
@@ -304,11 +318,11 @@ impl Deserialize for MacAddress {
                 value.parse().map_err(|err| E::syntax(&format!("{}", err)))
             }
 
-            fn visit_bytes<E: de::Error>(&mut self, value: &[u8]) -> Result<Uuid, E> {
-                MacAddress::from_bytes(value).ok_or(E::syntax("Expected 6 bytes."))
+            fn visit_bytes<E: de::Error>(&mut self, value: &[u8]) -> Result<MacAddress, E> {
+                MacAddress::from_bytes(value).map_err(|_| E::syntax("Expected 6 bytes."))
             }
         }
-        deserializer.visit(UuidVisitor)
+        deserializer.visit(MacAddressVisitor)
     }
 }
 


### PR DESCRIPTION
This branch does two things:

* Makes the code compile with `--features=serde`.
* Brings the serde dependency up to date (as the user needs to have the same version of serde as the crate depends on, there's little use of supporting 0.6 now, when 1.0 is finally out).

I'll try to find out if it is possible to have one set of features as default and another to be run with `cargo test` and include some tests for serde as well. But in the meantime, it would be great if this gets updated.