### PR TITLE
added repr(C) to MacAddress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub const EUI64LEN: usize = 8;
 pub type Eui64 = [u8; EUI64LEN];
 
 /// A MAC address (EUI-48)
+#[repr(C)]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MacAddress {
     /// The 48-bit number stored in 6 bytes


### PR DESCRIPTION
Hi,  I am using  MacAddress in an interface to a C library. I always get a warning about the missing #[repr(C)]. Is there anything which speaks against adding this?

Thanks
Rainer