### PR TITLE
Make rustc-serialize optional to help WASM targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [dependencies]
-rustc-serialize = "0.3.24"
+rustc-serialize = { version = "0.3.24", optional = true }
 serde = { version = "1.0.80", optional = true }
 serde_json = { version = "1.0.37", optional = true }
 
@@ -35,6 +35,6 @@ gitlab = { repository = "abaumhauer/eui48", branch = "master" }
 appveyor = { repository = "abaumhauer/eui48", branch = "master", service = "github" }
 
 [features]
-default = []
+default = ["rustc-serialize"]
 disp_hexstring = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -28,6 +29,7 @@ use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
 
+#[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 #[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -333,6 +335,7 @@ impl Error for ParseError {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl Encodable for MacAddress {
     /// Encode a MacAddress as canonical form
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
@@ -340,6 +343,7 @@ impl Encodable for MacAddress {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl Decodable for MacAddress {
     /// Decode a MacAddress from a string in canonical form
     fn decode<D: Decoder>(d: &mut D) -> Result<MacAddress, D::Error> {


### PR DESCRIPTION
rustc-serialize does not build for targets like wasm32-unknown-unknown
and this is probably not going to change, c.f. [1]. To make this crate
usable on these targets without removing functionality, this change makes the
dependency on rustc-serialize optional but default.

[1] https://github.com/rustwasm/team/issues/96