### PR TITLE
Rustc-serialize and serde now respect the disp_hexstring flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub enum ParseError {
 impl MacAddress {
     /// Create a new MacAddress from `[u8; 6]`.
     pub fn new(eui: Eui48) -> MacAddress {
-        MacAddress { eui: eui }
+        MacAddress { eui }
     }
 
     /// Create a new MacAddress from a byte slice.
@@ -303,7 +303,7 @@ impl fmt::Debug for MacAddress {
 }
 
 impl fmt::Display for MacAddress {
-    /// Display format is canonical format (00-00-00-00-00-00)
+    /// Display format is canonical format (00-00-00-00-00-00) by default
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let disp_fmt = MacAddress::get_display_format();
         write!(f, "{}", self.to_string(disp_fmt))
@@ -334,9 +334,10 @@ impl Error for ParseError {
 }
 
 impl Encodable for MacAddress {
-    /// Encode a MacAddress as canonical form
+    /// Encode a MacAddress using the default format
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
-        e.emit_str(&self.to_canonical())
+        let disp_fmt = MacAddress::get_display_format();
+        e.emit_str(&self.to_string(disp_fmt))
     }
 }
 
@@ -350,9 +351,10 @@ impl Decodable for MacAddress {
 
 #[cfg(feature = "serde")]
 impl Serialize for MacAddress {
-    /// Serialize a MacAddress as canonical form using the serde crate
+    /// Serialize a MacAddress in the default format using the serde crate
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_canonical())
+        let disp_fmt = MacAddress::get_display_format();
+        serializer.serialize_str(&self.to_string(disp_fmt))
     }
 }
 


### PR DESCRIPTION
Hey,

As a follow up to #14 , I noticed the `disp_hexstring` flag wasn't respected by the serialization frameworks, this PR fixes it.