### PR TITLE
Remove broken documentation link from Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 readme = "README.md"
 repository = "https://github.com/abaumhauer/eui48"
 homepage = "https://github.com/abaumhauer/eui48"
-documentation = "https://doc.rust-lang.org/eui48"
 keywords = ["EUI-48", "MAC", "MAC-48", "networking", "MACADDR"]
 categories = ["network-programming", "parser-implementations"]
 description = """


### PR DESCRIPTION
The old link https://doc.rust-lang.org/eui48 was broken. The correct link is https://docs.rs/eui48, but by just omitting it crates.io will automatically link to the right place including the version, e.g. https://docs.rs/eui48/1.0.0.