### PR TITLE
Fix MacAddress::to_link_local()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,10 @@ impl MacAddress {
         )
     }
 
-    /// Returns a String representation in the IPv6 link local format 'ff80::0000:00ff:fe00:0000'
+    /// Returns a String representation in the IPv6 link local format 'fe80::0000:00ff:fe00:0000'
     pub fn to_link_local(&self) -> String {
         format!(
-            "ff80::{:02x}{:02x}:{:02x}ff:fe{:02x}:{:02x}{:02x}",
+            "fe80::{:02x}{:02x}:{:02x}ff:fe{:02x}:{:02x}{:02x}",
             (self.eui[0] ^ 0x02),
             self.eui[1],
             self.eui[2],
@@ -513,7 +513,7 @@ mod tests {
     fn test_to_link_local() {
         let eui: Eui48 = [0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF];
         let mac = MacAddress::new(eui);
-        assert_eq!("ff80::1034:56ff:feab:cdef", mac.to_link_local());
+        assert_eq!("fe80::1034:56ff:feab:cdef", mac.to_link_local());
     }
 
     #[test]


### PR DESCRIPTION
fe80::/10 is the prefix for "Link-Scoped Unicast" ([ipv6-address-space](https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.txt))
ff80::/16 would be multicast but bit 3 in "flgs" isn't defined ([RFC4291 section 2.7](https://tools.ietf.org/html/rfc4291#page-13))