### PR TITLE
Fixed IPv6 to_link_local() which had wrong prefix for Link-Scoped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eui48"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Andrew Baumhauer <andy@baumhauer.us>",
            "<rlcomstock3@github.com>",
            "Michal 'vorner' Vaner <vorner+github@vorner.cz>",
@@ -25,10 +25,10 @@ exclude = [
 ]
 
 [dependencies]
-regex = { version = "1.3.7", optional = false }
+regex = { version = "1.3.9", optional = false }
 rustc-serialize = { version = "0.3.24", optional = true }
-serde = { version = "1.0.106", optional = true }
-serde_json = { version = "1.0.51", optional = true }
+serde = { version = "1.0.114", optional = true }
+serde_json = { version = "1.0.56", optional = true }
 
 [badges]
 travis-ci = { repository = "abaumhauer/eui48", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -79,4 +79,6 @@ Version 1.0.0 and above allows a more flexible parsing of MAC address strings, c
 - 0.4.8 @kamek-pf - respect disp_hexstring flag
 - 0.4.9 Sebastian Dietze - New const added
 - 0.5.0 Andrew Baumhauer - cleanup, update versions, fmt, merge PRs, update unit tests
+- 0.5.1 jrb0001 - Fixed incorrect IPv6 to_link_local for Link-Scoped Unicast
 - 1.0.0 Stan Drozd, @rlcomstock3, and Andrew Baumhauer - merged all forks and improvements back to this repo
+- 1.0.1 jrb0001 - Fixed incorrect IPv6 to_link_local for Link-Scoped Unicast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,10 @@ impl MacAddress {
         )
     }
 
-    /// Returns a String representation in the IPv6 link local format 'ff80::0000:00ff:fe00:0000'
+    /// Returns a String representation in the IPv6 link local format 'fe80::0000:00ff:fe00:0000'
     pub fn to_link_local(&self) -> String {
         format!(
-            "ff80::{:02x}{:02x}:{:02x}ff:fe{:02x}:{:02x}{:02x}",
+            "fe80::{:02x}{:02x}:{:02x}ff:fe{:02x}:{:02x}{:02x}",
             (self.eui[0] ^ 0x02),
             self.eui[1],
             self.eui[2],
@@ -513,7 +513,7 @@ mod tests {
     fn test_to_link_local() {
         let eui: Eui48 = [0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF];
         let mac = MacAddress::new(eui);
-        assert_eq!("ff80::1034:56ff:feab:cdef", mac.to_link_local());
+        assert_eq!("fe80::1034:56ff:feab:cdef", mac.to_link_local());
     }
 
     #[test]


### PR DESCRIPTION
Unicast. Bumped library versions.