### PR TITLE
optimize binary serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eui48"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Andrew Baumhauer <andy@baumhauer.us>",
            "<rlcomstock3@github.com>",
            "Michal 'vorner' Vaner <vorner+github@vorner.cz>",
@@ -30,6 +30,9 @@ rustc-serialize = { version = "0.3.24", optional = true }
 serde = { version = "1.0.114", optional = true }
 serde_json = { version = "1.0.56", optional = true }
 
+[dev-dependencies]
+bincode = "1.3.1"
+
 [badges]
 travis-ci = { repository = "abaumhauer/eui48", branch = "master" }
 codecov = { repository = "abaumhauer/eui48", branch = "master", service = "github" }
@@ -39,3 +42,4 @@ appveyor = { repository = "abaumhauer/eui48", branch = "master", service = "gith
 [features]
 default = ["rustc-serialize"]
 disp_hexstring = []
+serde_bytes = ["serde"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Version 1.0.0 and above allows a more flexible parsing of MAC address strings, c
 * Rewrite parse_str to use a regex and be more lenient (now it permits one-off string chopping errors and mixed delimiters are accepted as long as we manage to read 6 bytes)
 * Exchange the InvalidCharacter error enum value for InvalidByteCount - InvalidCharacter is no longer supported. See versions >=0.5.0 and < 1.0.0 if you need legacy behavior.
 
+## Serialization
+When using `serde` to serialize a MAC address the address is stored as a formatted string. This fits well for text-based protocols like JSON but creates overhead for binary serialization. The overhead gets even bigger when the string is deserialized again, as a full-grown parser is needed instead of reading raw bytes. To reduce this overhead use the `serde_bytes` feature when serializing and deserializing MAC addresses to binary protocols. 
+
+NOTE: `serde_bytes` and `serde_json` are mutually exclusive!
+
 ## References
 [Wikipedia: MAC address](https://en.wikipedia.org/wiki/MAC_address)
 
@@ -82,3 +87,4 @@ Version 1.0.0 and above allows a more flexible parsing of MAC address strings, c
 - 0.5.1 jrb0001 - Fixed incorrect IPv6 to_link_local for Link-Scoped Unicast
 - 1.0.0 Stan Drozd, @rlcomstock3, and Andrew Baumhauer - merged all forks and improvements back to this repo
 - 1.0.1 jrb0001 - Fixed incorrect IPv6 to_link_local for Link-Scoped Unicast
+- 1.1.0 Felix Schreiner - binary serialization optimization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,20 +644,20 @@ mod tests {
     fn test_compare() {
         let m1 = MacAddress::nil();
         let m2 = MacAddress::broadcast();
-        assert!(m1 == m1);
-        assert!(m2 == m2);
-        assert!(m1 != m2);
-        assert!(m2 != m1);
+        assert_eq!(m1, m1);
+        assert_eq!(m2, m2);
+        assert_ne!(m1, m2);
+        assert_ne!(m2, m1);
     }
 
     #[test]
     fn test_clone() {
         let m1 = MacAddress::parse_str("12:34:56:AB:CD:EF").unwrap();
-        let m2 = m1.clone();
-        assert!(m1 == m1);
-        assert!(m2 == m2);
-        assert!(m1 == m2);
-        assert!(m2 == m1);
+        let m2 = m1;
+        assert_eq!(m1, m1);
+        assert_eq!(m2, m2);
+        assert_eq!(m1, m2);
+        assert_eq!(m2, m1);
     }
 
     #[test]
@@ -773,7 +773,7 @@ mod tests {
         );
         assert_eq!(
             "Invalid length; expecting 11 to 17 chars, found 2".to_owned(),
-            format!("{}", ParseError::InvalidLength(2).to_string())
+            ParseError::InvalidLength(2).to_string()
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl Decodable for MacAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", not(feature = "serde_bytes")))]
 impl Serialize for MacAddress {
     /// Serialize a MacAddress in the default format using the serde crate
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -337,7 +337,15 @@ impl Serialize for MacAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_bytes")]
+impl Serialize for MacAddress {
+    /// Serialize a MacAddress as raw bytes using the serde crate
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.as_bytes())
+    }
+}
+
+#[cfg(all(feature = "serde", not(feature = "serde_bytes")))]
 impl<'de> Deserialize<'de> for MacAddress {
     /// Deserialize a MacAddress from canonical form using the serde crate
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -345,22 +353,35 @@ impl<'de> Deserialize<'de> for MacAddress {
         impl<'de> de::Visitor<'de> for MacAddressVisitor {
             type Value = MacAddress;
 
-            fn visit_str<E: de::Error>(self, value: &str) -> Result<MacAddress, E> {
-                value.parse().map_err(|err| E::custom(&format!("{}", err)))
-            }
-
-            fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<MacAddress, E> {
-                MacAddress::from_bytes(value).map_err(|_| E::invalid_length(value.len(), &self))
-            }
-
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(
-                    formatter,
-                    "either a string representation of a MAC address or 6-element byte array"
-                )
+                write!(formatter, "a string representation of a MAC address")
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                value.parse().map_err(|err| E::custom(&format!("{}", err)))
             }
         }
         deserializer.deserialize_str(MacAddressVisitor)
+    }
+}
+
+#[cfg(feature = "serde_bytes")]
+impl<'de> Deserialize<'de> for MacAddress {
+    /// Deserialize a MacAddress from raw bytes using the serde crate
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct MacAddressVisitor;
+        impl<'de> de::Visitor<'de> for MacAddressVisitor {
+            type Value = MacAddress;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "6-element byte array")
+            }
+
+            fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+                MacAddress::from_bytes(value).map_err(|_| E::invalid_length(value.len(), &self))
+            }
+        }
+        deserializer.deserialize_bytes(MacAddressVisitor)
     }
 }
 
@@ -757,6 +778,17 @@ mod tests {
     #[cfg(feature = "serde_json")]
     fn test_serde_json_deserialize_panic() {
         let _should_panic: MacAddress = serde_json::from_str("\"12\"").unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "serde_bytes")]
+    fn test_serde_bytes_serialization_roundtrip() {
+        use bincode;
+        let mac = MacAddress::parse_str("12:34:56:AB:CD:EF").unwrap();
+        let mut buffer = Vec::new();
+        bincode::serialize_into(&mut buffer, &mac).unwrap();
+        let deserialized: MacAddress = bincode::deserialize_from(&*buffer).unwrap();
+        assert_eq!(deserialized, mac);
     }
 
     #[test]


### PR DESCRIPTION
First things first: I really like this crate and use it in many of my projects! Unfortunately the `serde` serialization implementation is only optimized for human readable formats like JSON. Using it with a binary serialization protocol results in massively degraded performance. This is because the MAC address is first converted into a human readable string on serialization and later parsed using a full-grown parser on de-serialization. While this is okay for most projects, it kills the performance of mine, as I frequently serialize and de-serialize MAC addresses to pass them into a WASM container.

This PR introduces a new feature called "serde_bytes" changeing the implementation of the serialization/de-serialization code into a better optimized one. This feature is intended to be used for binary serialization.