### PR TITLE
Remove rustc-serialize from default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ gitlab = { repository = "abaumhauer/eui48", branch = "master" }
 appveyor = { repository = "abaumhauer/eui48", branch = "master", service = "github" }
 
 [features]
-default = ["rustc-serialize"]
+default = []
 disp_hexstring = []
 serde_bytes = ["serde"]
+rustc_serialize = ["rustc-serialize"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,6 +681,7 @@ mod tests {
         assert_eq!(m2, m1);
     }
 
+    #[cfg(feature = "rustc_serialize")]
     #[test]
     fn test_serialize() {
         use rustc_serialize::json;
@@ -694,6 +695,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "rustc_serialize")]
     #[test]
     fn test_deserialize() {
         use rustc_serialize::json;
@@ -709,6 +711,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "rustc_serialize")]
     #[test]
     fn test_serialize_roundtrip() {
         use rustc_serialize::json;


### PR DESCRIPTION
With https://rustsec.org/advisories/RUSTSEC-2022-0004 and the
unmaintained status of rustc-serialize, it makes sense to downgrade
rustc-serialize to an optional feature, or remove it altogether.