### PR TITLE
Update rustc-serialize to 0.3.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "eui48"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Andrew Baumhauer <andy@baumhauer.us>",
            "<rlcomstock3@github.com>",
            "Michal 'vorner' Vaner <vorner+github@vorner.cz>",
-	   "Stan Drozd <drozdziak1@gmail.com>" ]
+	   "Stan Drozd <drozdziak1@gmail.com>",
+	   "Hans Christian Lonstad <hcl@datarespons.no>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 readme = "README.md"
@@ -26,7 +27,7 @@ exclude = [
 
 [dependencies]
 regex = { version = "1.3.9", optional = false }
-rustc-serialize = { version = "0.3.24", optional = true }
+rustc-serialize = { version = "0.3.25", optional = true }
 serde = { version = "1.0.114", optional = true }
 serde_json = { version = "1.0.56", optional = true }
 


### PR DESCRIPTION
Fixes lifetime issue in rustc-serialize 0.3.24

```

Compiling rustc-serialize v0.3.24
error[E0310]: the parameter type `T` may not live long enough
    --> rustc-serialize-0.3.24/src/serialize.rs:1155:5
     |
1155 |     fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |     |
     |     the parameter type `T` must be valid for the static lifetime...
     |     ...so that the type `T` will meet its required lifetime bounds...
     |
note: ...that is required by this bound
    --> rustlib/src/rust/library/alloc/src/borrow.rs:180:30
     |
180  | pub enum Cow<'a, B: ?Sized + 'a>
     |                              ^^
help: consider adding an explicit lifetime bound
     |
1151 | impl<'a, T: ?Sized + 'static> Decodable for Cow<'a, T>
     |                    +++++++++
```
