### PR TITLE
Remove rustc-serialize from the default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ gitlab = { repository = "abaumhauer/eui48", branch = "master" }
 appveyor = { repository = "abaumhauer/eui48", branch = "master", service = "github" }
 
 [features]
-default = ["rustc-serialize"]
+default = []
 disp_hexstring = []
 serde_bytes = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,6 +682,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rustc-serialize")]
     fn test_serialize() {
         use rustc_serialize::json;
 
@@ -695,6 +696,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rustc-serialize")]
     fn test_deserialize() {
         use rustc_serialize::json;
 
@@ -710,6 +712,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rustc-serialize")]
     fn test_serialize_roundtrip() {
         use rustc_serialize::json;
 


### PR DESCRIPTION
The rustc-serialize crate is deprecated and the repository archived since Dec 1, 2023.