### PR TITLE
Added thiserror for improved error handling in ParseError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ regex = { version = "1.3.9", optional = false }
 rustc-serialize = { version = "0.3.24", optional = true }
 serde = { version = "1.0.114", optional = true }
 serde_json = { version = "1.0.56", optional = true }
+thiserror = "1.0.65"
 
 [dev-dependencies]
 bincode = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eui48"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Andrew Baumhauer <andy@baumhauer.us>",
            "<rlcomstock3@github.com>",
            "Michal 'vorner' Vaner <vorner+github@vorner.cz>",
@@ -25,14 +25,14 @@ exclude = [
 ]
 
 [dependencies]
-regex = { version = "1.3.9", optional = false }
-rustc-serialize = { version = "0.3.24", optional = true }
-serde = { version = "1.0.114", optional = true }
-serde_json = { version = "1.0.56", optional = true }
+regex = { version = "1.11.1", optional = false }
+rustc-serialize = { version = "0.3.25", optional = true }
+serde = { version = "1.0.214", optional = true }
+serde_json = { version = "1.0.132", optional = true }
 thiserror = "1.0.65"
 
 [dev-dependencies]
-bincode = "1.3.1"
+bincode = "1.3.3"
 
 [badges]
 travis-ci = { repository = "abaumhauer/eui48", branch = "master" }


### PR DESCRIPTION
This PR introduces `thiserror` for `ParseError`, which simplifies error handling by using automatic trait implementations and providing clear error messages. This reduces the verbosity of the code while improving readability and maintainability.
